### PR TITLE
Add Sourashtra Dictionary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ dictpress is a free and open source, single binary webserver application for bui
 Example dictionaries:
 - [Alar](https://alar.ink/) — Kannada-English dictionary.
 - [Olam](https://olam.in/) — English-Malayalam, Malayalam-Malayalam dictionary.
+- [Sourashtra Dictionary](https://dictionary.thinnal.org/) - Sourashtra English, Sourashtra Tamil dictionary.
 
 
 ## Features


### PR DESCRIPTION
Add reference to Sourashtra  Dictionary (https://en.wikipedia.org/wiki/Saurashtra_language )  developed using Dictpress. It has  6,500 Sourashtra words now.

Dictionary link - https://dictionary.thinnal.org
