### PR TITLE
Make entry `content` an array `content[]`. This is a breaking change.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build: $(BIN)
 $(STUFFBIN):
 	go install github.com/knadh/stuffbin/...
 
-$(BIN): $(shell find . -type f -name "*.go")
+$(BIN): $(shell find . -type f -name "*.go") ${STATIC}
 	CGO_ENABLED=0 go build -o ${BIN} -ldflags="-s -w -X 'main.buildString=${BUILDSTR}' -X 'main.versionString=${VERSION}'" cmd/${BIN}/*.go
 
 .PHONY: run

--- a/admin/definition.html
+++ b/admin/definition.html
@@ -7,11 +7,21 @@
         <div class="panel relation-form">
             <h3>Add definition</h3>
             <form @submit.prevent="onSave">
-                <div x-text="parent.content"></div>
+                <div>
+                    <template x-for="(item, idx) in parent.content" :key="idx">
+                        <span x-text="item" style="display: block;"></span>
+                    </template>
+                </div>
                 <div>&darr;</div>
                 <div>
                     <label>Definition</label>
-                    <textarea required autofocus name="content" x-ref="content" x-model="def.content"></textarea>
+                    <template x-for="(item, idx) in def.content" :key="idx">
+                        <div style="margin-bottom: 0.5rem;">
+                            <textarea required x-model="def.content[idx]" x-ref="contentInput" :autofocus="idx === 0" style="width: calc(100% - 60px); display: inline-block;"></textarea>
+                            <a href="#" @click.prevent="onDeleteDefContentItem(idx)" x-show="def.content.length > 1" style="margin-left: 0.5rem;">Delete</a>
+                        </div>
+                    </template>
+                    <a href="#" @click.prevent="onAddDefContentItem">+ Add</a>
                 </div>
                 <br />
                 <template x-if="Object.keys(config.languages[parent.lang].types).length > 0">

--- a/admin/entry.html
+++ b/admin/entry.html
@@ -11,7 +11,13 @@
                     <div class="row">
                         <div class="column nine">
                             <label>Content</label>
-                            <textarea required autofocus name="content" x-ref="content" x-model="entry.content"></textarea>
+                            <template x-for="(item, idx) in entry.content" :key="idx">
+                                <div style="margin-bottom: 0.5rem;">
+                                    <textarea required x-model="entry.content[idx]" x-ref="contentInput" :autofocus="idx === 0"></textarea>
+                                    <a href="#" @click.prevent="onDeleteContentItem(idx)" x-show="entry.content.length > 1" class="text-xsmall float-right">Delete</a>
+                                </div>
+                            </template>
+                            <a href="#" @click.prevent="onAddContentItem">+ Add</a>
                         </div>
                         <div class="column three">
                             <label>Initial</label>
@@ -106,7 +112,11 @@
                         <template x-for="r in parentEntries" :key="r.id">
                             <li class="rel">
                                 <p>
-                                    <a x-bind:href="makeURL({'id': r.id})" x-text="r.content" class="content"></a>
+                                    <a x-bind:href="makeURL({'id': r.id})" class="content">
+                                        <template x-for="(item, idx) in r.content" :key="idx">
+                                            <span><span x-text="item"></span><span x-show="idx < r.content.length - 1">, </span></span>
+                                        </template>
+                                    </a>
                                     <template x-if="r.phones.length > 0">
                                         <span class="phones" x-text="r.phones.join(', ')"></span>
                                     </template>

--- a/admin/pending.html
+++ b/admin/pending.html
@@ -24,7 +24,11 @@
                         <span class="tag new">New word</span>
                     </template>
                     <h3>
-                        <a x-bind:href="makeURL({id: e.id})" @click.prevent="onEditEntry(e)" x-text="e.content"></a>
+                        <a x-bind:href="makeURL({id: e.id})" @click.prevent="onEditEntry(e)">
+                            <template x-for="(item, idx) in e.content" :key="idx">
+                                <span><span x-text="item"></span><span x-show="idx < e.content.length - 1">, </span></span>
+                            </template>
+                        </a>
                     </h3>
                     <sup class="lang meta" x-text="config.languages[e.lang].name"></sup>
 
@@ -50,7 +54,12 @@
                                     <span class="tag" :class="{ [r.relation.status]: true }" x-text="r.relation.status"></span>
                                 </template>
                                 <span class="meta lang" x-text="config.languages[r.lang].name"></span>
-                                <span class="meta types" x-text="r.relation.types"></span> <span x-text="r.content" class="content"></span>
+                                <span class="meta types" x-text="r.relation.types"></span>
+                                <span class="content">
+                                    <template x-for="(item, idx) in r.content" :key="idx">
+                                        <span><span x-text="item"></span><span x-show="idx < r.content.length - 1">, </span></span>
+                                    </template>
+                                </span>
                             </p>
                             <template x-if="e.id in comments && r.id in comments[e.id]">
                                 <template x-for="(c, n) in comments[e.id][r.id]" :key="c.id">

--- a/admin/search.html
+++ b/admin/search.html
@@ -19,7 +19,11 @@
 
                 <div class="heading">
                     <h3>
-                        <a x-bind:href="makeURL({id: e.id})" @click.prevent="onEditEntry(e)" x-text="e.content"></a>
+                        <a x-bind:href="makeURL({id: e.id})" @click.prevent="onEditEntry(e)">
+                            <template x-for="(item, idx) in e.content" :key="idx">
+                                <span><span x-text="item"></span><span x-show="idx < e.content.length - 1">, </span></span>
+                            </template>
+                        </a>
                     </h3>
                     <sup class="lang" x-text="config.languages[e.lang].name"></sup>
                 </div>
@@ -30,7 +34,12 @@
                         <li class="rel" :class="{ highlight: order[e.id] && order[e.id].changedRels[r.id] }">
                             <p>
                                 <span class="meta lang" x-text="config.languages[r.lang].name"></span>
-                                <span class="meta types" x-text="r.relation.types"></span> <span x-text="r.content" class="content"></span>
+                                <span class="meta types" x-text="r.relation.types"></span>
+                                <span class="content">
+                                    <template x-for="(item, idx) in r.content" :key="idx">
+                                        <span><span x-text="item"></span><span x-show="idx < r.content.length - 1">, </span></span>
+                                    </template>
+                                </span>
                             </p>
                             <div class="actions">
                                 <a href="#" @click.prevent="onDetatchRelation(e.id, r.relation.id)">Detatch</a>

--- a/admin/static/main.js
+++ b/admin/static/main.js
@@ -96,6 +96,7 @@ function globalComponent() {
 
         onNewEntry() {
             this.$dispatch('open-entry-form', {
+                content: [''],
                 weight: 0,
                 lang: Object.keys(this.config.languages)[0],
                 tokens: '',
@@ -349,6 +350,7 @@ function entryComponent() {
             const data = e.detail;
             this.entry = {
                 ...data,
+                content: Array.isArray(data.content) ? [...data.content] : [data.content || ''],
                 phones: data.phones.join('\n'),
                 tags: data.tags.join('\n'),
                 tokens: data.tokens.split(' ').join('\n'),
@@ -358,12 +360,18 @@ function entryComponent() {
             this.isNew = !this.entry.id ? true : false;
             this.isVisible = true;
 
-            this.$nextTick(() => {
-                this.$refs.content.focus();
-            });
-
             if (this.entry.parent) {
                 this.getParentEntries(this.entry.id);
+            }
+        },
+
+        onAddContentItem() {
+            this.entry.content.push('');
+        },
+
+        onDeleteContentItem(idx) {
+            if (this.entry.content.length > 1) {
+                this.entry.content.splice(idx, 1);
             }
         },
 
@@ -373,8 +381,8 @@ function entryComponent() {
         },
 
         onFocusInitial() {
-            if (!this.entry.initial && this.entry.content && this.entry.content.length > 0) {
-                this.entry.initial = this.entry.content[0].toUpperCase();
+            if (!this.entry.initial && Array.isArray(this.entry.content) && this.entry.content.length > 0 && this.entry.content[0].length > 0) {
+                this.entry.initial = this.entry.content[0][0].toUpperCase();
             }
         },
 
@@ -398,7 +406,8 @@ function entryComponent() {
 
             let data = {
                 ...this.entry,
-                initial: this.entry.initial ? this.entry.initial : this.entry.content[0].toUpperCase(),
+                content: this.entry.content.filter(c => c.trim() !== ''),
+                initial: this.entry.initial ? this.entry.initial : (this.entry.content.length > 0 && this.entry.content[0].length > 0 ? this.entry.content[0][0].toUpperCase() : ''),
                 phones: linesToList(this.entry.phones),
                 tags: linesToList(this.entry.tags),
                 tokens: linesToList(this.entry.tokens).join(' ')
@@ -498,17 +507,28 @@ function definitionComponent() {
             this.parent = e.detail.parent;
             delete (e.detail.parent);
 
-            this.def = { ...e.detail, tags: e.detail.tags.join('\n') };
+            this.def = {
+                ...e.detail,
+                content: [''],
+                tags: e.detail.tags.join('\n')
+            };
             this.isVisible = true;
-            this.$nextTick(() => {
-                this.$refs.content.focus();
-            });
+        },
+
+        onAddDefContentItem() {
+            this.def.content.push('');
+        },
+
+        onDeleteDefContentItem(idx) {
+            if (this.def.content.length > 1) {
+                this.def.content.splice(idx, 1);
+            }
         },
 
         onSave() {
             const params = {
-                content: this.def.content,
-                initial: this.def.content[0].toUpperCase(),
+                content: this.def.content.filter(c => c.trim() !== ''),
+                initial: this.def.content.length > 0 && this.def.content[0].length > 0 ? this.def.content[0][0].toUpperCase() : '',
                 lang: this.def.lang,
                 phones: [],
                 tags: [],

--- a/admin/static/style.css
+++ b/admin/static/style.css
@@ -140,6 +140,10 @@ section {
   margin-bottom: 45px;
 }
 
+.text-xsmall {
+  font-size: 0.775rem;
+}
+
 .box {
   border: 1px solid #ddd;
   border-radius: 3px;

--- a/cmd/dictpress/submit.go
+++ b/cmd/dictpress/submit.go
@@ -88,7 +88,7 @@ func handleNewSubmission(c echo.Context) error {
 	e := data.Entry{
 		Lang:    s.EntryLang,
 		Initial: strings.ToUpper(string(s.EntryContent[0])),
-		Content: s.EntryContent,
+		Content: pq.StringArray([]string{s.EntryContent}),
 		Phones:  pq.StringArray(phones),
 		Tags:    pq.StringArray{},
 		Status:  data.StatusPending,
@@ -113,8 +113,8 @@ func handleNewSubmission(c echo.Context) error {
 
 		toID, err := app.data.InsertSubmissionEntry(data.Entry{
 			Lang:    s.RelationLang[i],
-			Initial: strings.ToUpper(string(s.RelationContent[0][0])),
-			Content: s.RelationContent[i],
+			Initial: strings.ToUpper(string(s.RelationContent[i][0])),
+			Content: pq.StringArray([]string{s.RelationContent[i]}),
 			Phones:  pq.StringArray(phones),
 			Tags:    pq.StringArray{},
 			Status:  data.StatusPending,

--- a/cmd/dictpress/upgrade.go
+++ b/cmd/dictpress/upgrade.go
@@ -26,6 +26,7 @@ type migFunc struct {
 // The functions are named as: v0.7.0 => migrations.V0_7_0() and are idempotent.
 var migList = []migFunc{
 	{"v2.0.0", migrations.V2_0_0},
+	{"v4.0.0", migrations.V4_0_0},
 }
 
 // upgrade upgrades the database to the current version by running SQL migration files

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -19,7 +19,7 @@ type Entry struct {
 	Weight    float64        `json:"weight" db:"weight"`
 	Initial   string         `json:"initial" db:"initial"`
 	Lang      string         `json:"lang" db:"lang"`
-	Content   string         `json:"content" db:"content"`
+	Content   pq.StringArray `json:"content" db:"content"`
 	Tokens    string         `json:"tokens" db:"tokens"`
 	Tags      pq.StringArray `json:"tags" db:"tags"`
 	Phones    pq.StringArray `json:"phones" db:"phones"`
@@ -62,9 +62,9 @@ type Relation struct {
 
 // GlossaryWord to read glosary content from db.
 type GlossaryWord struct {
-	ID      int    `json:"id,omitempty" db:"id"`
-	Content string `json:"content" db:"content"`
-	Total   int    `json:"-" db:"total"`
+	ID      int            `json:"id,omitempty" db:"id"`
+	Content pq.StringArray `json:"content" db:"content"`
+	Total   int            `json:"-" db:"total"`
 }
 
 // Stats contains database statistics.

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -238,7 +238,7 @@ func (im *Importer) insertEntries(entries []entry, lineStart int) error {
 	stmt = tx.Stmtx(im.stmtInsertEntry)
 	for i, e := range entries {
 		if err := stmt.Get(&entryIDs[i],
-			e.Content,
+			pq.StringArray([]string{e.Content}),
 			e.Initial,
 			lineStart,
 			e.TSVectorTokens,
@@ -275,7 +275,7 @@ func (im *Importer) insertEntries(entries []entry, lineStart int) error {
 			// Insert the definition entry and record the resulting ID
 			// against the parent ID.
 			if err := stmt.Get(&relIDs[i][j],
-				e.Content,
+				pq.StringArray([]string{e.Content}),
 				e.Initial,
 				i+j,
 				e.TSVectorTokens,

--- a/schema.sql
+++ b/schema.sql
@@ -12,7 +12,7 @@ CREATE TABLE entries (
     guid            UUID NOT NULL UNIQUE DEFAULT GEN_RANDOM_UUID(),
 
     -- Actual language content. Dictionary word or definition entries
-    content         TEXT NOT NULL CHECK (content <> ''),
+    content         TEXT[] NOT NULL CHECK (ARRAY_LENGTH(content, 1) > 0),
 
     -- The first “alphabet” of the content. For English, for the word Apple, the initial is A
     initial         TEXT NOT NULL DEFAULT '',
@@ -42,7 +42,7 @@ CREATE TABLE entries (
     created_at      TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at      TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-DROP INDEX IF EXISTS idx_content; CREATE INDEX idx_entries_content ON entries((LOWER(SUBSTRING(content, 0, 50))));
+DROP INDEX IF EXISTS idx_content; CREATE INDEX idx_entries_content ON entries((LOWER(SUBSTRING(content[1], 0, 50))));
 DROP INDEX IF EXISTS idx_entries_initial; CREATE INDEX idx_entries_initial ON entries(initial);
 DROP INDEX IF EXISTS idx_entries_lang; CREATE INDEX idx_entries_lang ON entries(lang);
 DROP INDEX IF EXISTS idx_entries_tokens; CREATE INDEX idx_entries_tokens ON entries USING GIN(tokens);

--- a/site/glossary-words.html
+++ b/site/glossary-words.html
@@ -6,7 +6,7 @@
 {{ else }}
     <ul class="noul words">
         {{ range $i, $w := $g.Words }}
-            <li><a href="{{ $.Consts.RootURL }}/dictionary/{{ UnicodeURL $g.FromLang }}/{{ UnicodeURL $g.ToLang }}/{{ UnicodeURL $w.Content }}">{{ $w.Content }}</a></li>
+            <li><a href="{{ $.Consts.RootURL }}/dictionary/{{ UnicodeURL $g.FromLang }}/{{ UnicodeURL $g.ToLang }}/{{ UnicodeURL (index $w.Content 0) }}">{{ $w.Content | join ", " }}</a></li>
         {{ end }}
     </ul>
 {{ end }}

--- a/site/results.html
+++ b/site/results.html
@@ -7,9 +7,9 @@
                 <li class="entry" data-guid="{{ $r.GUID }}">
                     <header class="head">
                         {{ if $.Consts.EnableSubmissions }}
-                            <a href="#" data-from="{{ $r.GUID }}" class="edit" title="{{ $.L.Ts "public.suggestEdit" "word" $r.Content }}">✏️</a>
+                            <a href="#" data-from="{{ $r.GUID }}" class="edit" title="{{ $.L.Ts "public.suggestEdit" "word" ($r.Content | join ", ") }}">✏️</a>
                         {{ end }}
-                        <h3 class="title">{{ $r.Content }}</h3>
+                        <h3 class="title">{{ $r.Content | join ", " }}</h3>
 
                         {{ if $r.Phones }}
                             <span class="pronun">♪ {{ $r.Phones | join "," }}</span>
@@ -35,11 +35,11 @@
 
                             <li>
                                 <div data-guid="{{ $d.GUID }}" class="def">
-                                    {{ $d.Content }}
+                                    {{ $d.Content | join ", " }}
 
                                     {{ if $.Consts.EnableSubmissions }}
                                         <a href="#" data-from="{{ $r.GUID }}" data-to="{{ $d.GUID }}"
-                                            class="edit" title="{{ $.L.Ts "public.suggestEdit" "word" $d.Content }}">✏️</a>
+                                            class="edit" title="{{ $.L.Ts "public.suggestEdit" "word" ($d.Content | join ", ") }}">✏️</a>
                                     {{ end }}
                                 </div>
                             </li>
@@ -58,7 +58,7 @@
             <h4>{{ .L.T "public.similarTitle" }}</h4>
             <ul>
             {{ range $k, $r := (mustSlice .Data.Results.Entries $numResults) }}
-                <li><a href="{{ UnicodeURL $r.Content }}">{{ $r.Content }}</a></li>
+                <li><a href="{{ UnicodeURL (index $r.Content 0) }}">{{ $r.Content | join ", " }}</a></li>
             {{ end }}
             </ul>
         {{ end }}


### PR DESCRIPTION
This patch refactors the `entries.content` table field from TEXT to TEXT[] to support multiple content values per entry (e.g., alternative spellings, transliterations, or script variations of the same word).

This was added after working with the Kurup Malayalam thesaurus, where each "definition" entry is actually a series of synonyms. Rather than joining everything with a comma and dumping in `content`, it's better to provision for multiple values.

- Break to version v4.0.0
- Database schema: `content TEXT` to `content TEXT[]`
- APIs: `content` is now an array in all JSON responses and reqest payloads